### PR TITLE
fix for kind test results not uploading

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -15,11 +15,13 @@ jobs:
         run: |
           ./test/e2e-minimal.sh
       - name: Upload test results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v1
         with:
           name: test-results
           path: test-results/
-      - name: Upload snapshots
+      - name: Upload snapshotsA
+        if: ${{ always() }}
         uses: actions/upload-artifact@v1
         with:
           name: snapshot


### PR DESCRIPTION
@teodor-pripoae I see the new GH Action steps for uploading test results are not executing when the tests **fail** :frowning_face: 

I *think* this might fix it

([from here](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions))